### PR TITLE
Making the tag unicode

### DIFF
--- a/content_edit/templatetags/content_edit_tags.py
+++ b/content_edit/templatetags/content_edit_tags.py
@@ -53,7 +53,7 @@ class CmsContentNode(template.Node):
 
         # Generate content
         if change_perm:
-            html_content = '<div id="content_{0}" onblur="save_cms_content(this, \'{0}\')" contenteditable="true">{1}</div>'.format(
+            html_content = u'<div id="content_{0}" onblur="save_cms_content(this, \'{0}\')" contenteditable="true">{1}</div>'.format(
                 content.name, content.content)
         else:
             html_content = content.content


### PR DESCRIPTION
The tag raised an error in editing mode if the content contained special characters
