### PR TITLE
Removed django-ckeditor from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
         'Intended Audience :: System Administrators',
         "License :: OSI Approved :: BSD License",
     ],
-    install_requires=['django', 'django-ckeditor', 'django-reversion']
+    install_requires=['django', 'django-reversion']
 )


### PR DESCRIPTION
django-ckeditor requires and installs pillow which is a rather "big requirement" which most of the people might not need and which might make trouble to install in certain environments.
