### PR TITLE
Django 1.9 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 settings_local.py
+db.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.5
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ COPY . /usr/src/app
 # include RUN for tests as well as CMD so that all test dependencies are
 # installed on the image and wont have to be downloaded again every time
 # the image is RUN
-RUN python setup.py test
-CMD python setup.py test
+CMD python manage.py test

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ just need a few editable areas in your templates.
 
 # Setup
 
+This currently support Django 1.9 and Python 3.5.
+
 1. `pip install django-content-edit`
 1. Run `python manage.py syncdb --migrate` You can run without south's --migrate, but I don't suggest it.
 1. Add `'content_edit',` to INSTALLED_APPS

--- a/content_edit/admin.py
+++ b/content_edit/admin.py
@@ -2,12 +2,12 @@ from django.contrib import admin
 from django.forms.widgets import Textarea
 
 from ckeditor.fields import RichTextField
-import reversion
+import reversion.admin
 
 from content_edit.models import CmsContent
 from content_edit.settings import *
 
-class CmsContentAdmin(reversion.VersionAdmin):
+class CmsContentAdmin(reversion.admin.VersionAdmin):
     list_display = ('name', 'site',)
     list_filter = ('site',)
     search_fields = ('name','content')

--- a/content_edit/templatetags/content_edit_tags.py
+++ b/content_edit/templatetags/content_edit_tags.py
@@ -1,7 +1,7 @@
 from django import template
-from django.contrib.auth.models import AnonymousUser 
+from django.contrib.auth.models import AnonymousUser
 try:
-    from django.contrib.sites.models import get_current_site
+    from django.contrib.sites.shortcuts import get_current_site
     site = True
 except:
     site = False
@@ -74,4 +74,3 @@ def do_cms_content(parser, token):
             raise template.TemplateSyntaxError(
                 "%r tag's argument should be in quotes" % tag_name)
     return CmsContentNode(content_name[1:-1])
-

--- a/content_edit/urls.py
+++ b/content_edit/urls.py
@@ -1,8 +1,7 @@
-from django.conf.urls import *
+from django.conf.urls import url
 from content_edit import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url('^ajax_save_content/$', views.ajax_save_content, name='ajax_save_content'),
     url('^sample_content_edit/$', views.sample_content_edit, name='sample_content_edit'),
-
-)
+]

--- a/content_edit_proj/settings.py
+++ b/content_edit_proj/settings.py
@@ -22,8 +22,6 @@ SECRET_KEY = '*idvi++k)bkpecw)57uro8&5hqo0+6_2k7(k8mp8xkso1=gk3n'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATE_DEBUG = True
-
 ALLOWED_HOSTS = []
 
 
@@ -85,3 +83,24 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
 STATIC_URL = '/static/'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
+                # list if you haven't customized them:
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]

--- a/content_edit_proj/urls.py
+++ b/content_edit_proj/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^content_edit/', include('content_edit.urls')),
-)
+]

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         'Intended Audience :: System Administrators',
         "License :: OSI Approved :: BSD License",
     ],
-    install_requires=['django', 'django-ckeditor-updated', 'django-reversion']
+    install_requires=['django', 'django-ckeditor', 'django-reversion']
 )


### PR DESCRIPTION
This [does not support Django 1.9 as is](https://travis-ci.org/burke-software/django-content-edit/builds/65719939). In order to support it we need to support a newer version of django-reversion. This adds support for that, mainly just renaming a few imports.
